### PR TITLE
fix(deps): upgrade rustls-webpki to 0.103.13 to patch security issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,15 +1322,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Re-pins `rustls-webpki` to `0.103.13` (and bumps `rustls-pki-types` to `1.14.1` to satisfy its minimum) after the dependabot bump of `headless_chrome` in #223 re-resolved the lock file back to the vulnerable `0.103.3` release.

## Why

`rustls-webpki 0.103.3` (a transitive dependency via `headless_chrome` → `auto_generate_cdp` → `ureq` → `rustls`) has four known advisories, all of which were resolved in the upstream patch release `0.103.13` and originally patched for this repo in #222:

- **RUSTSEC-2026-0049** (moderate): CRLs not considered authoritative by Distribution Point due to faulty matching logic
- **RUSTSEC-2026-0098** (moderate): Name constraints for URI names were incorrectly accepted
- **RUSTSEC-2026-0099** (moderate): Name constraints were accepted for certificates asserting a wildcard name
- **RUSTSEC-2026-0104** (high): Reachable panic in certificate revocation list parsing

Resolves dependabot alert #32.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo fmt --check` clean
- [x] `cargo audit` no longer reports any `rustls-webpki` advisories (only pre-existing unmaintained warnings remain)
- [x] `cargo clippy` shows no new issues (the three pre-existing warnings on `main` are unchanged)
- [x] Dependabot alert #32 resolved after merge